### PR TITLE
Feature/auth addressbook api apidocs

### DIFF
--- a/backend/api/v1/api_docs.py
+++ b/backend/api/v1/api_docs.py
@@ -1,0 +1,25 @@
+from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
+from rest_framework import permissions
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Address-book RESTful API",
+        default_version='v1',
+        description=(
+            ": 사용자의 연락처 정보를 관리하고 조회하기 위한 API 서비스입니다.\n\n"
+            "- **'연락처(Contact)'**, **'라벨(Label)'** 에 대하여 `추가`, `목록 조회`, `상세 조회`, `전체 수정`, `부분 수정`, `삭제` 기능을 제공합니다.\n\n"
+            "- **'연락처(Contact)'** 에 다수의 **'라벨(Label)'** 을 `연결`하거나 `해제`할 수 있습니다.\n"
+            "- 특정 **'라벨(Label)'** 과 연결된 다수의 **'연락처(Contact)'** 를 `목록 조회`할 수 있습니다."
+        ),
+        terms_of_service="https://www.<서비스도메인>.com/terms/",
+        contact=openapi.Contact(
+            name="Backend Team",
+            email="humblem2@naver.com",
+            url="https://www.<서비스도메인>.com/support/teamblog/주소록"
+        ),
+    ),
+    public=True,
+    permission_classes=[permissions.AllowAny, ],
+    authentication_classes=[],
+)

--- a/backend/api/v1/contact/serializers.py
+++ b/backend/api/v1/contact/serializers.py
@@ -1,1 +1,57 @@
-"""TODO: 필요시 Contact Value-Object 관련 serializer 추가"""
+from rest_framework import serializers
+
+from api.v1 import (
+    validators as v
+)
+from api.v1.label import (
+    serializers as ls,
+)
+from apps.addressbook import (
+    models as m,
+)
+from commons import (
+    serializer_mixins as sm,
+)
+
+
+class ContactListSerializer(sm.BaseModelSerializer):
+    """Contact모델 목록 조회 시 사용"""
+
+    phone_number = serializers.CharField(validators=[v.is_valid_phone_number])
+    labels = serializers.SerializerMethodField(help_text="연락처에 매핑된 라벨의 리스트입니다.")
+
+    class Meta:
+        model = m.Contact
+        fields = ('id', 'profile_pic', 'name', 'email', 'phone_number',
+                  'company', 'position', 'labels', 'created_at', 'updated_at')
+        ref_name = "Contact - (List)"
+
+    def get_labels(self, obj):
+        """@overide 연락처 모델 조회 시 라벨 정보도 같이 나오도록 재정의한 메서드"""
+
+        labels = m.Label.objects.filter(contactlabel_set__contact=obj)
+        return ls.LabelSerializer(labels, many=True).data
+
+
+class ContactDetailSerializer(serializers.ModelSerializer):
+    """Contact모델 상세, 수정, 생성 시 사용"""
+
+    phone_number = serializers.CharField(validators=[v.is_valid_phone_number])
+    labels = serializers.SerializerMethodField()
+
+    class Meta:
+        model = m.Contact
+        fields = ('id', 'profile_pic', 'name', 'email', 'phone_number',
+                  'company', 'position', 'memo', 'labels', 'address',
+                  'birthday', 'website', 'created_at', 'updated_at')
+        ref_name = 'Contact - (Detail)'
+
+    def get_labels(self, obj):
+        labels = m.Label.objects.filter(contactlabel_set__contact=obj)
+        return ls.LabelSerializer(labels, many=True).data
+
+    def create(self, validated_data):
+        """역직렬화시 user 필드가 필수(FK) 필드이므로, user 정보 추가 후 생성"""
+        user = self.context['request'].user
+        validated_data['user'] = user
+        return super().create(validated_data)

--- a/backend/api/v1/contact/views.py
+++ b/backend/api/v1/contact/views.py
@@ -1,1 +1,73 @@
-"""TODO: 필요시 Contact Value-Object 관련 views(@RestController) 추가"""
+from rest_framework import viewsets, mixins
+from rest_framework.permissions import IsAuthenticated
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+from api.v1 import (
+    paginators as pn,
+    permissions as pm,
+)
+from api.v1.contact import (
+    serializers as cs,
+)
+from apps.addressbook import (
+    models as m,
+)
+
+
+class ContactViewSet(viewsets.ModelViewSet):
+    """Contact 테이블에 대한 CRUD API"""
+
+    queryset = m.Contact.objects.all()
+    pagination_class = pn.DefaultContactPagination
+    permission_classes = [IsAuthenticated]
+    authentication_classes = [JWTAuthentication]
+
+    def get_queryset(self):
+        """@overide 로그인 유저의 연락처 및 정렬"""
+        if not self.request.user.is_authenticated:
+            return m.Contact.objects.none()
+
+        queryset = m.Contact.objects.all()
+        ordering = self.request.query_params.get('ordering', None)
+
+        if ordering in ['name', 'email', 'phone_number', '-name', '-email', '-phone_number', '-id']:
+            queryset = queryset.order_by(ordering)
+        else:
+            queryset = queryset.order_by('id')
+
+        return queryset.filter(user=self.request.user)
+
+    def get_serializer_class(self):
+        """현재 요청 액션에 따라 적절한 시리얼라이저를 반환"""
+        if self.action == 'list':
+            return cs.ContactListSerializer
+        else:
+            return cs.ContactDetailSerializer
+
+    def perform_create(self, serializer):
+        """@overide 연락처 생성 시 필수 필드인 로그인 유저 정보를 넣어 DB에 저장 (labels 필드는 동시에 저장하지 않음)"""
+        serializer.save(user=self.request.user)
+
+
+class LabelContactsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+    """특정 라벨에 대응되는 `연락처 리스트`"""
+
+    queryset = m.Contact.objects.all()
+    serializer_class = cs.ContactListSerializer
+    pagination_class = pn.DefaultContactPagination
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated, pm.IsOwnerOfContact]
+
+    def get_queryset(self):
+        """@overide URL에서 `label` 쿼리 파라미터를 기반으로 특정 라벨에 해당하는 연락처리스트를 반환"""
+        if not self.request.user.is_authenticated:
+            return m.Contact.objects.none()
+
+        queryset = m.Contact.objects.filter(user=self.request.user)
+
+        label_id = self.request.query_params.get('label', None)
+        if label_id:
+            contact_ids = m.ContactLabel.objects.filter(label=label_id).values_list('contact', flat=True)
+            queryset = queryset.filter(id__in=contact_ids)
+        return queryset
+

--- a/backend/api/v1/contact_label/serializers.py
+++ b/backend/api/v1/contact_label/serializers.py
@@ -1,1 +1,17 @@
-"""TODO: 필요시 Contact Value-Object 관련 serializer 추가"""
+from rest_framework import serializers
+
+from apps.addressbook import (
+    models as m,
+)
+from commons import (
+    serializer_mixins as sm,
+)
+
+
+class ContactLabelSerializer(sm.BaseModelSerializer):
+    """ContactLabel 모델의 생성, 삭제 시 사용"""
+
+    class Meta:
+        model = m.ContactLabel
+        fields = ('id', 'contact', 'label')
+        ref_name = "ContactLabel"

--- a/backend/api/v1/contact_label/urls.py
+++ b/backend/api/v1/contact_label/urls.py
@@ -1,1 +1,1 @@
-"""TODO: 필요시 Contact Value-Object 관련 url 추가"""
+"""TODO: 필요시 ContactLabel Value-Object 관련 url 추가"""

--- a/backend/api/v1/contact_label/views.py
+++ b/backend/api/v1/contact_label/views.py
@@ -1,1 +1,61 @@
-"""TODO: 필요시 Contact Value-Object 관련 views(@RestController) 추가"""
+from typing import Union
+
+from django.http import QueryDict
+from rest_framework import viewsets, status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+from api.v1 import (
+    paginators as pn,
+    permissions as pm,
+)
+from api.v1.contact_label import (
+    serializers as cls,
+)
+from apps.addressbook import (
+    models as m,
+)
+
+
+class ContactLabelViewSet(viewsets.ModelViewSet):
+    """ContactLabel 테이블에 대한 CRUD API"""
+
+    http_method_names = ['post', 'delete', 'head', 'options']
+    queryset = m.ContactLabel.objects.all()
+    pagination_class = pn.DefaultContactLabelPagination
+    serializer_class = cls.ContactLabelSerializer
+    permission_classes = [IsAuthenticated, pm.IsOwnerOfContactLabel]
+    authentication_classes = [JWTAuthentication]
+    
+    def get_queryset(self):
+        """로그인 유저의 연락처-라벨 매핑을 반환"""
+        if not self.request.user.is_authenticated:
+            return m.ContactLabel.objects.none()
+
+        queryset = m.ContactLabel.objects.filter(contact__user=self.request.user)
+
+        contact_id = self.request.query_params.get('contact', None)
+        if contact_id is not None:
+            queryset = queryset.filter(contact=contact_id)
+
+        label_id = self.request.query_params.get('label', None)
+        if label_id is not None:
+            queryset = queryset.filter(label=label_id)
+
+        return queryset
+
+    def create(self, request, *args, **kwargs):
+        """ContactLabel 테이블의 매핑을 생성하며, DB의 `(contact, label) 조합` 중복 검사"""
+
+        if self._is_duplicate_data(request.data):
+            return Response({"detail": "This contact_label mapping already exists."},
+                            status=status.HTTP_400_BAD_REQUEST)
+        return super().create(request, *args, **kwargs)
+
+    def _is_duplicate_data(self, data: Union[QueryDict, dict]) -> bool:
+        """연락처-라벨 매핑을 생성할 때, (contact, label) 조합이 이미 존재하는지 여부"""
+
+        contact_id = data.get('contact')
+        label_id = data.get('label')
+        return m.ContactLabel.objects.filter(contact_id=contact_id, label_id=label_id).exists()

--- a/backend/api/v1/label/serializers.py
+++ b/backend/api/v1/label/serializers.py
@@ -1,1 +1,26 @@
-"""TODO: 필요시 Contact Value-Object 관련 serializer 추가"""
+from rest_framework import serializers
+
+from apps.addressbook import (
+    models as m,
+)
+from commons import (
+    serializer_mixins as sm,
+)
+
+
+class LabelSerializer(sm.BaseModelSerializer):
+    """Label 모델의 조회 시 사용"""
+
+    class Meta:
+        model = m.Label
+        fields = ['id', 'name']
+        ref_name = 'Label'
+
+
+class LabelUpdateSerializer(serializers.ModelSerializer):
+    """Label 모델 상세, 수정, 생성 시 사용"""
+
+    class Meta:
+        model = m.Label
+        fields = ['name']
+        ref_name = 'Label (Update Only)'

--- a/backend/api/v1/label/urls.py
+++ b/backend/api/v1/label/urls.py
@@ -1,1 +1,1 @@
-"""TODO: 필요시 Contact Value-Object 관련 url 추가"""
+"""TODO: 필요시 Label Value-Object 관련 url 추가"""

--- a/backend/api/v1/label/views.py
+++ b/backend/api/v1/label/views.py
@@ -1,1 +1,35 @@
-"""TODO: 필요시 Contact Value-Object 관련 views(@RestController) 추가"""
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+from api.v1.label import (
+    serializers as ls,
+)
+from apps.addressbook import (
+    models as m,
+)
+
+
+class LabelViewSet(viewsets.ModelViewSet):
+    """Label 테이블에 대한 CRUD API"""
+
+    http_method_names = ['get', 'post', 'put', 'delete']
+    queryset = m.Label.objects.all()
+    serializer_class = ls.LabelSerializer
+    permission_classes = [IsAuthenticated]
+    authentication_classes = [JWTAuthentication]
+
+    def get_queryset(self):
+        """@overide 로그인 유저의 라벨"""
+        if not self.request.user.is_authenticated:
+            return m.Label.objects.none()  # 빈 쿼리셋 반환
+        return m.Label.objects.filter(user=self.request.user)
+
+    def get_serializer_class(self):
+        if self.request.method in ['PUT', 'PATCH']:
+            return ls.LabelUpdateSerializer
+        return ls.LabelSerializer
+
+    def perform_create(self, serializer):
+        """@overide 라벨 생성시 로그인 유저 정보를 넣어줌"""
+        serializer.save(user=self.request.user)

--- a/backend/api/v1/paginators.py
+++ b/backend/api/v1/paginators.py
@@ -1,0 +1,18 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class DefaultContactPagination(PageNumberPagination):
+    """연락처 테이블에 대한 기본 페이징"""
+    page_size = 5
+    page_size_query_param = 'page_size'
+    max_page_size = 100
+    last_page_strings = ['last']
+
+
+class DefaultContactLabelPagination(PageNumberPagination):
+    """연락처-라벨 테이블에 대한 기본 페이징"""
+    page_size = 20
+    page_size_query_param = 'page_size'
+    max_page_size = 100
+    last_page_strings = ['last']
+

--- a/backend/api/v1/permissions.py
+++ b/backend/api/v1/permissions.py
@@ -1,0 +1,17 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsOwnerOfContactLabel(BasePermission):
+    """연락처 라벨의 소유자만 해당 라벨을 수정하거나 삭제할 수 있는 권한"""
+
+    def has_object_permission(self, request, view, obj):
+        # Check if the current user is the owner of the contact label.
+        return obj.contact.user == request.user
+
+
+class IsOwnerOfContact(BasePermission):
+    """연락처의 소유자만 CRUD 작업을 수행 권한"""
+
+    def has_object_permission(self, request, view, obj):
+        # Check if the current user is the owner of the contact.
+        return obj.user == request.user

--- a/backend/api/v1/routers.py
+++ b/backend/api/v1/routers.py
@@ -1,0 +1,13 @@
+from rest_framework.routers import DefaultRouter
+
+from api.v1.contact.views import ContactViewSet, LabelContactsViewSet
+from api.v1.contact_label.views import ContactLabelViewSet
+from api.v1.label.views import LabelViewSet
+
+router = DefaultRouter()
+router.register(r'contacts', ContactViewSet, basename='contacts')
+router.register(r'contact-labels', ContactLabelViewSet, basename='contact-labels')
+router.register(r'labels', LabelViewSet, basename='labels')
+router.register(r'labels/(?P<label_id>\d+)/contacts', LabelContactsViewSet, basename='label-contacts')
+
+urlpatterns = router.urls

--- a/backend/api/v1/user/serializers.py
+++ b/backend/api/v1/user/serializers.py
@@ -1,1 +1,28 @@
-"""TODO: 필요시 Contact Value-Object 관련 serializer 추가"""
+from django.contrib.auth import get_user_model
+from rest_framework import serializers
+
+User = get_user_model()
+
+
+class UserRegisterSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(write_only=True)
+
+    class Meta:
+        model = User
+        fields = ('username', 'email', 'password')
+
+    def create(self, validated_data):
+        """비밀번호 해싱/암호화 후 유저 생성"""
+        user = User.objects.create_user(
+            username=validated_data['username'],
+            email=validated_data['email'],
+            password=validated_data['password']
+        )
+        return user
+
+
+class LoginSerializer(serializers.Serializer):
+    """로그인 요청 데이터 처리"""
+    email = serializers.EmailField()  # username 대신 email로 로그인
+    password = serializers.CharField(write_only=True)
+

--- a/backend/api/v1/user/urls.py
+++ b/backend/api/v1/user/urls.py
@@ -1,1 +1,8 @@
-"""TODO: 필요시 Contact Value-Object 관련 url 추가"""
+from django.urls import path
+
+from .views import RegisterView, LoginView
+
+urlpatterns = [
+    path('register/', RegisterView.as_view(), name='register'),
+    path('login/', LoginView.as_view(), name='login'),
+]

--- a/backend/api/v1/user/views.py
+++ b/backend/api/v1/user/views.py
@@ -1,1 +1,51 @@
-"""TODO: 필요시 Contact Value-Object 관련 views(@RestController) 추가"""
+from django.contrib.auth import get_user_model
+from rest_framework import permissions
+from rest_framework import status, generics
+from rest_framework.response import Response
+from rest_framework_simplejwt.exceptions import AuthenticationFailed
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from api.v1.user.serializers import UserRegisterSerializer, LoginSerializer
+
+User = get_user_model()
+
+
+class RegisterView(generics.CreateAPIView):
+    """회원가입"""
+
+    queryset = User.objects.all()
+    serializer_class = UserRegisterSerializer
+    permission_classes = [permissions.AllowAny]
+
+
+class LoginView(generics.GenericAPIView):
+    """로그인"""
+
+    serializer_class = LoginSerializer
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        # `검증데이터`에서 값 가져오기
+        email = serializer.validated_data['email']
+        password = serializer.validated_data['password']
+
+        # `아이디(이메일)`로 회원여부 확인
+        try:
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            print('User not found')
+            raise AuthenticationFailed('User not found')
+
+        # `비밀번호` 일치여부 확인
+        if not user.check_password(password):
+            print('Incorrect password')
+            raise AuthenticationFailed('Incorrect password')
+
+        # `유저`가 존재하고, `비밀번호`가 일치하면, `토큰` 발행
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+
+        return Response({'access_token': access_token}, status=status.HTTP_200_OK)

--- a/backend/api/v1/validators.py
+++ b/backend/api/v1/validators.py
@@ -1,0 +1,11 @@
+import re
+
+from rest_framework.exceptions import ValidationError
+
+
+def is_valid_phone_number(number: str):
+    """(KR) 휴대폰번호 또는 일반전화번호 형식인지 검사"""
+    mobile_pattern = r'^010-\d{3,4}-\d{4}$'
+    landline_pattern = r'^(02|031|032|033|041|042|043|044|051|052|053|054|055|061|062|063|064)-\d{3,4}-\d{4}$'
+    if not (re.match(mobile_pattern, number) or re.match(landline_pattern, number)):
+        raise ValidationError('This is not a valid phone number format. e.g., 010-1234-5678, 02-123-4567')

--- a/backend/commons/serializer_mixins.py
+++ b/backend/commons/serializer_mixins.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+
+class BaseModelSerializer(serializers.ModelSerializer):
+    created_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S", read_only=True)
+    updated_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S", read_only=True)
+
+    class Meta:
+        abstract = True

--- a/backend/conf/settings/base.py
+++ b/backend/conf/settings/base.py
@@ -136,3 +136,49 @@ DDL_BY_SQL = True
 
 # Custom User Model
 AUTH_USER_MODEL = 'accounts.User'
+
+# Django-Rest-Framework
+REST_FRAMEWORK = {
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.JSONRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer',
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+    ],
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',  # Simple JWT 토큰을 사용하여 사용자를 인증
+    ),
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 10,
+}
+
+# Simple JWT
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=30),
+    'SLIDING_TOKEN_REFRESH_LIFETIME': timedelta(days=15),
+    'ROTATE_REFRESH_TOKENS': True,
+    'ALGORITHM': 'HS256',
+    'SIGNING_KEY': SECRET_KEY,
+    'VERIFYING_KEY': None,
+    'AUTH_HEADER_TYPES': ('Bearer',),
+    'USER_ID_FIELD': 'id',
+    'USER_ID_CLAIM': 'user_id',
+    'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),
+    'TOKEN_TYPE_CLAIM': 'token_type',
+}
+
+# Swagger
+SWAGGER_SETTINGS = {
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+    ],
+    'SECURITY_DEFINITIONS': {
+        'Bearer': {
+            'type': 'apiKey',
+            'name': 'Authorization',
+            'in': 'header'
+        }
+    },
+}
+

--- a/backend/conf/urls.py
+++ b/backend/conf/urls.py
@@ -17,8 +17,14 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import path, include, re_path
 
+from api.v1.api_docs import schema_view
+from api.v1.routers import urlpatterns as api_v1_addressbook_urlpatterns
+from api.v1.user.urls import urlpatterns as api_v1_auth_urlpatterns
+
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/', include(api_v1_auth_urlpatterns)),
+    path('api/', include(api_v1_addressbook_urlpatterns)),
 ]
 
 if settings.DEBUG:
@@ -26,3 +32,9 @@ if settings.DEBUG:
     urlpatterns = [
         re_path(r'^__debug__/', include(debug_toolbar.urls)),
     ] + urlpatterns
+
+    urlpatterns += [
+        re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+        path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+        path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+    ]

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -5,8 +5,7 @@ import sys
 from typing import Dict
 
 import pymysql
-from decouple import Config, RepositoryEnv
-from decouple import config
+from decouple import Config, config, RepositoryEnv
 from termcolor import colored
 
 from conf.settings.base import BASE_DIR


### PR DESCRIPTION
---

## **내용**:

### 관련된 Git-issues
> #4, #5, #6, #9

---

### API 및 API-DOC(Swagger): 인증, 연락처/라벨 관리, 페이지네이션, Swagger
> 이 PR에는 사용자 인증, 연락처 및 라벨 관리 API, 페이지네이션, 연락처 정렬, 그리고 Swagger를 활용한 API 문서화와 관련된 내용이 포함되어 있습니다.

--- 

### 1. **인증 및 JWT 토큰 도입** (#4):
   - 회원가입 및 로그인 기능 구현
   - JWT를 활용한 사용자 인증 방식 도입

| 기능                              | 동작                      | URI                                     |
|----------------------------------|---------------------------|-----------------------------------------|
| **인증**                          |                           |                                         |
| - 회원가입                         | 생성                      | `/api/register/`                     |
| - 로그인                           | 인증                      | `/api/login/`                      |

### 2. **연락처, 라벨, 연락처-라벨(중간테이블) 관리 API 구현** (#5):
| 기능                              | 동작                      | URI                                     |
|----------------------------------|---------------------------|-----------------------------------------|
| **라벨**                          |                           |                                         |
| - 라벨 목록                        | 조회                      | `/api/labels/`                          |
| - 라벨 상세                        | 조회                      | `/api/labels/<label_id>/`               |
| - 라벨                             | 생성                      | `/api/labels/`                          |
| - 라벨                             | 전체수정                  | `/api/labels/<label_id>/`               |
| - 라벨                             | 삭제                      | `/api/labels/<label_id>/`               |
| - 라벨에 매핑되는 연락처 목록      | 조회                      | `/api/labels/<label_id>/contacts/`      |
| **연락처**                        |                           |                                         |
| - 연락처                           | 생성                      | `/api/contacts/`                        |
| - 연락처 목록                     | 조회                      | `/api/contacts/`                        |
| - 연락처 상세                     | 조회                      | `/api/contacts/<contact_id>/`           |
| - 연락처                           | 부분수정                  | `/api/contacts/<contact_id>/`           |
| - 연락처                           | 전체수정                  | `/api/contacts/<contact_id>/`           |
| - 연락처                           | 삭제                      | `/api/contacts/<contact_id>/`           |
| **연락처-라벨 (중간테이블)**      |                           |                                         |
| - 연락처-라벨                       | 생성                      | `/api/contact-label/`                   |
| - 연락처-라벨                       | 삭제                      | `/api/contact-label/<mapping_id>/`      |
| **인증**                          |                           |                                         |
| - 회원가입                         | 생성                      | `/api/auth/signup/`                     |
| - 로그인                           | 인증                      | `/api/auth/login/`                      |

### 3. **API 페이지네이션** (#6):
   - API 응답에 페이지네이션 적용
   - 페이지네이션 클래스 구현 및 추상화 적용
   - conf/settings/~ 의 settings 파일(`base.py`)에 디폴트 페이지네이션 적용
   - Domain(Contact, Label,...) 마다 페이지네이션 설정 커스텀 하게 관리 (`paginators.py`)

### 4. **API 문서화 및 Swagger 도입** (#9):
   - Swagger를 활용하여 API 문서화 구현
   - redoc와의 확장성 고려하여 설계
   - `Swagger 접속 URL`: `<IP>:<PORT>/swagger/`
   - `Redoc 접속 URL`: `<IP>:<PORT>/redoc/`

---
